### PR TITLE
Add: benchmarking. Fix: Ignore negative numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,23 @@ const commonDenominators = require('common-denominators');
 
 commonDenominators(6, 12, 24, 30); // -> [1, 2, 3, 6]
 ```
+
+## Development
+
+Run tests (and benchmark on success)
+
+```javascript
+npm run validate
+```
+
+Run tests only
+
+```javascript
+npm run test
+```
+
+Run benchmark only
+
+```javascript
+npm run benchmark
+```

--- a/index.benchmark.js
+++ b/index.benchmark.js
@@ -1,0 +1,19 @@
+const Benchmark = require('benchmark');
+const suite = new Benchmark.Suite();
+
+const commonDenominators = require('./index');
+
+let testCase = [];
+
+for (let i = 0; i < 10000; i++) {
+    testCase.push(Math.floor(Math.random() * 10000));
+}
+
+suite
+    .add('commonDenominators', function() {
+        commonDenominators(...testCase);
+    })
+    .on('cycle', function(event) {
+        console.info('\x1b[33m%s\x1b[0m', String(event.target));
+    })
+    .run({ async: true });

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function commonDenominators() {
     const allNumerators = Array.from(
         new Set(
             Object.values(arguments).filter(
-                numerator => Number.isInteger(numerator) && numerator !== 0
+                numerator => Number.isInteger(numerator) && numerator > 0
             )
         )
     ).sort((denominator, next) => denominator - next);

--- a/index.test.js
+++ b/index.test.js
@@ -1,36 +1,43 @@
 const commonDenominators = require('./index');
 
 describe('common denominators', () => {
-    it('should take nothing and return []', () => {
+    it('should take no arguments and return []', () => {
         let output = commonDenominators();
         let expected = [];
 
         expect(output).toEqual(expected);
     });
 
-    it('should take all invalid arguments and return an array of []', () => {
+    it('should take all invalid arguments and return []', () => {
         let output = commonDenominators('', {}, []);
         let expected = [];
 
         expect(output).toEqual(expected);
     });
 
-    it('should take number 8 and return an array of [1, 2, 4, 8] ', () => {
+    it('should take a single number 8 and return [1, 2, 4, 8] ', () => {
         let output = commonDenominators(8);
         let expected = [1, 2, 4, 8];
 
         expect(output).toEqual(expected);
     });
 
-    it('should take a mixed amount of arguments including 6 and 10 and invalid values and 1, 2, 3, 6', () => {
+    it('should take invalid arguments and 6 and 10 and return [1, 2, 3, 6]', () => {
         let output = commonDenominators(6, 12, '', {}, []);
         let expected = [1, 2, 3, 6];
 
         expect(output).toEqual(expected);
     });
 
-    it('should take unsorted arguments of numbers and still return ordered denominators of 1, 2, 3, 6', () => {
+    it('should take unsorted arguments and return [1, 2, 3, 6]', () => {
         let output = commonDenominators(12, 6, '', {}, []);
+        let expected = [1, 2, 3, 6];
+
+        expect(output).toEqual(expected);
+    });
+
+    it('should take ignore negative numbers', () => {
+        let output = commonDenominators(12, 6, -6);
         let expected = [1, 2, 3, 6];
 
         expect(output).toEqual(expected);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "common-denominators",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -515,6 +515,16 @@
             "optional": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
+            }
+        },
+        "benchmark": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+            "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.4",
+                "platform": "^1.3.3"
             }
         },
         "brace-expansion": {
@@ -3994,6 +4004,12 @@
             "requires": {
                 "find-up": "^2.1.0"
             }
+        },
+        "platform": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+            "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+            "dev": true
         },
         "pn": {
             "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -3,16 +3,22 @@
     "version": "1.0.1",
     "author": "Emett Speer, Eric Lakatos",
     "license": "MIT",
-    "description": "A JS function that takes any number of arguments and returns any array of all the common denominators of any numbers supplied",
+    "description": "A JS function that takes any number of arguments and returns an array of all the common denominators of any numbers supplied",
     "repository": {
         "type": "git",
         "url": "https://github.com/ericlakatos/common-denominators"
     },
     "main": "index.js",
     "scripts": {
+        "validate": "jest && npm run benchmark",
+        "benchmark": "node index.benchmark.js",
         "test": "jest"
     },
     "devDependencies": {
+        "benchmark": "^2.1.4",
         "jest": "23.2.0"
-    }
+    },
+    "keywords": [
+        "common denominators"
+    ]
 }


### PR DESCRIPTION
Added in benchmark.js. You can run it via CLI alone or with the tests upon success.

Function now ignores negative numbers (for now?)